### PR TITLE
[feat] #186 - 알림 API 연동 및 푸시 권한 플로우 구현

### DIFF
--- a/POTI-iOS/POTI-iOS/Application/AppDIContainer.swift
+++ b/POTI-iOS/POTI-iOS/Application/AppDIContainer.swift
@@ -6,7 +6,6 @@
 //
 
 final class AppDIContainer {
-
     static let shared = AppDIContainer()
     private init() {}
 
@@ -50,8 +49,12 @@ final class AppDIContainer {
         DefaultPostRepository(networkService: makeNetworkService())
     }
 
-    private func makeSearchRepository() -> SearchRepository {
+    private func makeSearchRepository() -> SearchInterface {
         DefaultSearchRepository(networkService: makeNetworkService())
+    }
+
+    private func makeNotificationRepository() -> NotificationInterface {
+        DefaultNotificationRepository(networkService: makeNetworkService())
     }
 
     private func makeArtistsRepository() -> ArtistsInterface {
@@ -132,6 +135,26 @@ final class AppDIContainer {
 
     private func makeSearchPostsUseCase() -> SearchPostsUseCase {
         DefaultSearchPostsUseCase(repository: makeSearchRepository())
+    }
+
+    private func makeFetchNotificationsUseCase() -> FetchNotificationsUseCase {
+        DefaultFetchNotificationsUseCase(repository: makeNotificationRepository())
+    }
+
+    private func makeReadNotificationUseCase() -> ReadNotificationUseCase {
+        DefaultReadNotificationUseCase(repository: makeNotificationRepository())
+    }
+
+    private func makeReadAllNotificationsUseCase() -> ReadAllNotificationsUseCase {
+        DefaultReadAllNotificationsUseCase(repository: makeNotificationRepository())
+    }
+
+    private func makeFetchNotificationSettingsUseCase() -> FetchNotificationSettingsUseCase {
+        DefaultFetchNotificationSettingsUseCase(repository: makeNotificationRepository())
+    }
+
+    private func makeUpdateNotificationSettingsUseCase() -> UpdateNotificationSettingsUseCase {
+        DefaultUpdateNotificationSettingsUseCase(repository: makeNotificationRepository())
     }
 
     private func makeApplyParticipationUseCase() -> ApplyParticipationUseCase {
@@ -241,11 +264,14 @@ final class AppDIContainer {
     }
 
     func makeNotificationViewModel() -> NotificationViewModel {
-        NotificationViewModel(notifications: NotificationItem.mockData)
+        NotificationViewModel(fetchNotificationsUseCase: makeFetchNotificationsUseCase(),
+                              readNotificationUseCase: makeReadNotificationUseCase(),
+                              readAllNotificationsUseCase: makeReadAllNotificationsUseCase())
     }
 
     func makeNotificationSettingViewModel() -> NotificationSettingViewModel {
-        NotificationSettingViewModel()
+        NotificationSettingViewModel(fetchNotificationSettingsUseCase: makeFetchNotificationSettingsUseCase(),
+                                     updateNotificationSettingsUseCase: makeUpdateNotificationSettingsUseCase())
     }
 
     func makePotDetailViewModel(postId: Int) -> PotDetailViewModel {

--- a/POTI-iOS/POTI-iOS/Core/Service/PushNotificationPermissionService.swift
+++ b/POTI-iOS/POTI-iOS/Core/Service/PushNotificationPermissionService.swift
@@ -1,0 +1,73 @@
+//
+//  PushNotificationPermissionService.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/28/26.
+//
+
+import UIKit
+import UserNotifications
+
+enum PushNotificationPermissionResult {
+    case granted
+    case denied
+    case openedSettings
+}
+
+protocol PushNotificationPermissionService {
+    func authorizationStatus() async -> UNAuthorizationStatus
+    func requestPermissionOrOpenSettings() async -> PushNotificationPermissionResult
+    func isPermissionAllowed() async -> Bool
+}
+
+final class DefaultPushNotificationPermissionService: PushNotificationPermissionService {
+    
+    // MARK: - Property
+
+    private let notificationCenter = UNUserNotificationCenter.current()
+
+    // MARK: - Public Methods
+    
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        await notificationCenter.notificationSettings().authorizationStatus
+    }
+
+    @MainActor
+    func requestPermissionOrOpenSettings() async -> PushNotificationPermissionResult {
+        switch await authorizationStatus() {
+        case .notDetermined:
+            do {
+                let isGranted = try await notificationCenter.requestAuthorization(options: [.alert, .badge, .sound])
+                if isGranted {
+                    UIApplication.shared.registerForRemoteNotifications()
+                    return .granted
+                }
+                return .denied
+            } catch {
+                PotiLogger.error(error)
+                return .denied
+            }
+
+        case .denied:
+            guard let settingsURL = URL(string: UIApplication.openNotificationSettingsURLString) else { return .denied }
+            await UIApplication.shared.open(settingsURL)
+            return .openedSettings
+
+        case .authorized, .provisional, .ephemeral:
+            UIApplication.shared.registerForRemoteNotifications()
+            return .granted
+
+        @unknown default:
+            return .denied
+        }
+    }
+
+    func isPermissionAllowed() async -> Bool {
+        switch await authorizationStatus() {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/POTI-iOS/POTI-iOS/Data/Network/Notification/DTO/NotificationResponseDTO.swift
+++ b/POTI-iOS/POTI-iOS/Data/Network/Notification/DTO/NotificationResponseDTO.swift
@@ -1,0 +1,30 @@
+//
+//  NotificationResponseDTO.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+struct NotificationResponseDTO: Decodable {
+    let content: [NotificationDTO]
+    let hasNext: Bool
+
+    func toEntity(currentPage: Int) -> NotificationPageEntity {
+        return NotificationPageEntity(notifications: content.map { $0.toEntity() }, currentPage: currentPage, hasNext: hasNext)
+    }
+}
+
+struct NotificationDTO: Decodable {
+    let id: Int
+    let title: String?
+    let body: String
+    let type: String
+    let deeplink: String?
+    let read: Bool
+    let createdAt: String
+
+    func toEntity() -> NotificationEntity {
+        return NotificationEntity(id: id, title: title ?? "", body: body, type: type,
+                                  deeplink: deeplink, isRead: read, createdAt: createdAt)
+    }
+}

--- a/POTI-iOS/POTI-iOS/Data/Network/Notification/DTO/NotificationSettingsDTO.swift
+++ b/POTI-iOS/POTI-iOS/Data/Network/Notification/DTO/NotificationSettingsDTO.swift
@@ -1,0 +1,16 @@
+//
+//  NotificationSettingsDTO.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+struct NotificationSettingsDTO: Decodable {
+    let tradeNotificationEnabled: Bool
+    let eventNotificationEnabled: Bool
+
+    func toEntity() -> NotificationSettingsEntity {
+        return NotificationSettingsEntity(isTradeNotificationEnabled: tradeNotificationEnabled,
+                                          isEventNotificationEnabled: eventNotificationEnabled)
+    }
+}

--- a/POTI-iOS/POTI-iOS/Data/Network/Notification/NotificationAPI.swift
+++ b/POTI-iOS/POTI-iOS/Data/Network/Notification/NotificationAPI.swift
@@ -1,0 +1,59 @@
+//
+//  NotificationAPI.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+import Alamofire
+
+enum NotificationAPI: BaseTargetType {
+    case fetchNotifications(page: Int)
+    case readNotification(notificationId: Int)
+    case readAllNotifications
+    case fetchSettings
+    case updateSettings(tradeNotificationEnabled: Bool, eventNotificationEnabled: Bool)
+
+    var path: String {
+        switch self {
+        case .fetchNotifications:
+            return "/api/v1/notifications"
+        case .readNotification(let notificationId):
+            return "/api/v1/notifications/\(notificationId)/read"
+        case .readAllNotifications:
+            return "/api/v1/notifications/read-all"
+        case .fetchSettings, .updateSettings:
+            return "/api/v1/notifications/settings"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .fetchNotifications, .fetchSettings:
+            return .get
+        case .readNotification, .readAllNotifications, .updateSettings:
+            return .patch
+        }
+    }
+
+    var queryParameters: [String: String]? {
+        switch self {
+        case .fetchNotifications(let page):
+            return ["page": "\(page)", "size": "20", "sort": "createdAt,desc"]
+        default:
+            return nil
+        }
+    }
+
+    var bodyParameters: Parameters? {
+        switch self {
+        case .updateSettings(let tradeNotificationEnabled, let eventNotificationEnabled):
+            return [
+                "tradeNotificationEnabled": tradeNotificationEnabled,
+                "eventNotificationEnabled": eventNotificationEnabled
+            ]
+        default:
+            return nil
+        }
+    }
+}

--- a/POTI-iOS/POTI-iOS/Data/Repository/DefaultNotificationRepository.swift
+++ b/POTI-iOS/POTI-iOS/Data/Repository/DefaultNotificationRepository.swift
@@ -1,0 +1,42 @@
+//
+//  DefaultNotificationRepository.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+final class DefaultNotificationRepository: NotificationInterface {
+    private let networkService: NetworkService
+
+    init(networkService: NetworkService) {
+        self.networkService = networkService
+    }
+
+    func fetchNotifications(page: Int) async throws -> NotificationPageEntity {
+        let response: NotificationResponseDTO = try await networkService.request(target: NotificationAPI.fetchNotifications(page: page),
+                                                                                  type: NotificationResponseDTO.self)
+        return response.toEntity(currentPage: page)
+    }
+
+    func readNotification(notificationId: Int) async throws {
+        let _: EmptyResponse = try await networkService.request(target: NotificationAPI.readNotification(notificationId: notificationId),
+                                                                type: EmptyResponse.self)
+    }
+
+    func readAllNotifications() async throws {
+        let _: EmptyResponse = try await networkService.request(target: NotificationAPI.readAllNotifications, type: EmptyResponse.self)
+    }
+
+    func fetchSettings() async throws -> NotificationSettingsEntity {
+        let response: NotificationSettingsDTO = try await networkService.request(target: NotificationAPI.fetchSettings,
+                                                                                  type: NotificationSettingsDTO.self)
+        return response.toEntity()
+    }
+
+    func updateSettings(tradeNotificationEnabled: Bool, eventNotificationEnabled: Bool) async throws -> NotificationSettingsEntity {
+        let response: NotificationSettingsDTO = try await networkService.request(
+            target: NotificationAPI.updateSettings(tradeNotificationEnabled: tradeNotificationEnabled,
+                                                   eventNotificationEnabled: eventNotificationEnabled), type: NotificationSettingsDTO.self)
+        return response.toEntity()
+    }
+}

--- a/POTI-iOS/POTI-iOS/Data/Repository/DefaultSearchRepository.swift
+++ b/POTI-iOS/POTI-iOS/Data/Repository/DefaultSearchRepository.swift
@@ -5,7 +5,7 @@
 //  Created by soomin on 8/17/26.
 //
 
-final class DefaultSearchRepository: SearchRepository {
+final class DefaultSearchRepository: SearchInterface {
     private let networkService: NetworkService
 
     init(networkService: NetworkService) {

--- a/POTI-iOS/POTI-iOS/Data/Repository/Mock/MockSearchRepository.swift
+++ b/POTI-iOS/POTI-iOS/Data/Repository/Mock/MockSearchRepository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class MockSearchRepository: SearchRepository {
+final class MockSearchRepository: SearchInterface {
     private let results: [SearchResultEntity]
     private let suggestions: [SearchSuggestionEntity]
 

--- a/POTI-iOS/POTI-iOS/Domain/Entity/Notification/NotificationEntity.swift
+++ b/POTI-iOS/POTI-iOS/Domain/Entity/Notification/NotificationEntity.swift
@@ -1,0 +1,22 @@
+//
+//  NotificationEntity.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+struct NotificationEntity {
+    let id: Int
+    let title: String
+    let body: String
+    let type: String
+    let deeplink: String?
+    let isRead: Bool
+    let createdAt: String
+}
+
+struct NotificationPageEntity {
+    let notifications: [NotificationEntity]
+    let currentPage: Int
+    let hasNext: Bool
+}

--- a/POTI-iOS/POTI-iOS/Domain/Entity/Notification/NotificationSettingsEntity.swift
+++ b/POTI-iOS/POTI-iOS/Domain/Entity/Notification/NotificationSettingsEntity.swift
@@ -1,0 +1,11 @@
+//
+//  NotificationSettingsEntity.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+struct NotificationSettingsEntity {
+    let isTradeNotificationEnabled: Bool
+    let isEventNotificationEnabled: Bool
+}

--- a/POTI-iOS/POTI-iOS/Domain/Interface/NotificationInterface.swift
+++ b/POTI-iOS/POTI-iOS/Domain/Interface/NotificationInterface.swift
@@ -1,0 +1,14 @@
+//
+//  NotificationInterface.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+protocol NotificationInterface {
+    func fetchNotifications(page: Int) async throws -> NotificationPageEntity
+    func readNotification(notificationId: Int) async throws
+    func readAllNotifications() async throws
+    func fetchSettings() async throws -> NotificationSettingsEntity
+    func updateSettings(tradeNotificationEnabled: Bool, eventNotificationEnabled: Bool) async throws -> NotificationSettingsEntity
+}

--- a/POTI-iOS/POTI-iOS/Domain/Interface/OrderManagementInterface.swift
+++ b/POTI-iOS/POTI-iOS/Domain/Interface/OrderManagementInterface.swift
@@ -5,11 +5,8 @@
 //  Created by soomin on 1/21/26.
 //
 
-
 protocol OrderManagementInterface {
     func patchTrackingNumber(orderId: Int, entity: TrackingNumberRequestEntity) async throws -> TrackingNumberResponseEntity
-
     func fetchManagerData(postId: Int) async throws -> ManageEntity
-
     func fetchSaleDetail(postId: Int) async throws -> RecruitDetailEntity
 }

--- a/POTI-iOS/POTI-iOS/Domain/Interface/SearchInterface.swift
+++ b/POTI-iOS/POTI-iOS/Domain/Interface/SearchInterface.swift
@@ -1,11 +1,11 @@
 //
-//  SearchRepository.swift
+//  SearchInterface.swift
 //  POTI-iOS
 //
 //  Created by soomin on 8/17/26.
 //
 
-protocol SearchRepository {
+protocol SearchInterface {
     func searchPosts(keyword: String, page: Int) async throws -> SearchResultPageEntity
     func fetchSuggestions(keyword: String) async throws -> [SearchSuggestionEntity]
 }

--- a/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/FetchNotificationSettingsUseCase.swift
+++ b/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/FetchNotificationSettingsUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  FetchNotificationSettingsUseCase.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+protocol FetchNotificationSettingsUseCase {
+    func execute() async throws -> NotificationSettingsEntity
+}
+
+final class DefaultFetchNotificationSettingsUseCase: FetchNotificationSettingsUseCase {
+    private let repository: NotificationInterface
+
+    init(repository: NotificationInterface) {
+        self.repository = repository
+    }
+
+    func execute() async throws -> NotificationSettingsEntity {
+        return try await repository.fetchSettings()
+    }
+}

--- a/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/FetchNotificationsUseCase.swift
+++ b/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/FetchNotificationsUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  FetchNotificationsUseCase.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+protocol FetchNotificationsUseCase {
+    func execute(page: Int) async throws -> NotificationPageEntity
+}
+
+final class DefaultFetchNotificationsUseCase: FetchNotificationsUseCase {
+    private let repository: NotificationInterface
+
+    init(repository: NotificationInterface) {
+        self.repository = repository
+    }
+
+    func execute(page: Int) async throws -> NotificationPageEntity {
+        return try await repository.fetchNotifications(page: page)
+    }
+}

--- a/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/ReadAllNotificationsUseCase.swift
+++ b/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/ReadAllNotificationsUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  ReadAllNotificationsUseCase.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+protocol ReadAllNotificationsUseCase {
+    func execute() async throws
+}
+
+final class DefaultReadAllNotificationsUseCase: ReadAllNotificationsUseCase {
+    private let repository: NotificationInterface
+
+    init(repository: NotificationInterface) {
+        self.repository = repository
+    }
+
+    func execute() async throws {
+        try await repository.readAllNotifications()
+    }
+}

--- a/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/ReadNotificationUseCase.swift
+++ b/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/ReadNotificationUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  ReadNotificationUseCase.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+protocol ReadNotificationUseCase {
+    func execute(notificationId: Int) async throws
+}
+
+final class DefaultReadNotificationUseCase: ReadNotificationUseCase {
+    private let repository: NotificationInterface
+
+    init(repository: NotificationInterface) {
+        self.repository = repository
+    }
+
+    func execute(notificationId: Int) async throws {
+        try await repository.readNotification(notificationId: notificationId)
+    }
+}

--- a/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/UpdateNotificationSettingsUseCase.swift
+++ b/POTI-iOS/POTI-iOS/Domain/UseCase/Notification/UpdateNotificationSettingsUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  UpdateNotificationSettingsUseCase.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+protocol UpdateNotificationSettingsUseCase {
+    func execute(tradeNotificationEnabled: Bool, eventNotificationEnabled: Bool) async throws -> NotificationSettingsEntity
+}
+
+final class DefaultUpdateNotificationSettingsUseCase: UpdateNotificationSettingsUseCase {
+    private let repository: NotificationInterface
+
+    init(repository: NotificationInterface) {
+        self.repository = repository
+    }
+
+    func execute(tradeNotificationEnabled: Bool, eventNotificationEnabled: Bool) async throws -> NotificationSettingsEntity {
+        return try await repository.updateSettings(tradeNotificationEnabled: tradeNotificationEnabled,
+                                                   eventNotificationEnabled: eventNotificationEnabled)
+    }
+}

--- a/POTI-iOS/POTI-iOS/Domain/UseCase/Search/FetchSearchSuggestionsUseCase.swift
+++ b/POTI-iOS/POTI-iOS/Domain/UseCase/Search/FetchSearchSuggestionsUseCase.swift
@@ -10,9 +10,9 @@ protocol FetchSearchSuggestionsUseCase {
 }
 
 final class DefaultFetchSearchSuggestionsUseCase: FetchSearchSuggestionsUseCase {
-    private let repository: SearchRepository
+    private let repository: SearchInterface
 
-    init(repository: SearchRepository) {
+    init(repository: SearchInterface) {
         self.repository = repository
     }
 

--- a/POTI-iOS/POTI-iOS/Domain/UseCase/Search/SearchPostsUseCase.swift
+++ b/POTI-iOS/POTI-iOS/Domain/UseCase/Search/SearchPostsUseCase.swift
@@ -10,9 +10,9 @@ protocol SearchPostsUseCase {
 }
 
 final class DefaultSearchPostsUseCase: SearchPostsUseCase {
-    private let repository: SearchRepository
+    private let repository: SearchInterface
 
-    init(repository: SearchRepository) {
+    init(repository: SearchInterface) {
         self.repository = repository
     }
 

--- a/POTI-iOS/POTI-iOS/Presentation/Common/Component/Toggle/PotiToggle.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Common/Component/Toggle/PotiToggle.swift
@@ -61,7 +61,8 @@ final class PotiToggle: UIControl {
 
     private func setLayout() {
         snp.makeConstraints {
-            $0.size.equalTo(46)
+            $0.width.equalTo(46)
+            $0.height.equalTo(26)
         }
 
         trackView.snp.makeConstraints {

--- a/POTI-iOS/POTI-iOS/Presentation/Common/Extension/String+.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Common/Extension/String+.swift
@@ -52,4 +52,29 @@ extension String {
         formatter.dateFormat = "yyyy-MM-dd H:mm"
         return formatter.string(from: date)
     }
+
+    func toRelativeTime(now: Date = Date()) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        guard let date = formatter.date(from: self) else { return "" }
+        let elapsedSeconds = max(0, Int(now.timeIntervalSince(date)))
+
+        switch elapsedSeconds {
+        case ..<60:
+            return "방금 전"
+        case ..<3600:
+            return "\(elapsedSeconds / 60)분 전"
+        case ..<86400:
+            return "\(elapsedSeconds / 3600)시간 전"
+        case ..<604800:
+            return "\(elapsedSeconds / 86400)일 전"
+        default:
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "MM.dd"
+            dateFormatter.locale = Locale(identifier: "ko_KR")
+            dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+            return dateFormatter.string(from: date)
+        }
+    }
 }

--- a/POTI-iOS/POTI-iOS/Presentation/Factory/ViewControllerFactory.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Factory/ViewControllerFactory.swift
@@ -9,6 +9,7 @@ protocol ViewControllerFactory {
     func makeLaunchScreenViewController() -> LaunchScreenViewController
     @MainActor func makeLoginViewController() -> LoginViewController
     func makePotiTabBar() -> PotiTabBar
+    func makePushNotificationPermissionCoordinator() -> PushNotificationPermissionCoordinator
     func makeHomeViewController() -> HomeViewController
     func makeNotificationViewController() -> NotificationViewController
     func makeNotificationSettingViewController() -> NotificationSettingViewController
@@ -40,6 +41,10 @@ protocol ViewControllerFactory {
 
 final class DefaultViewControllerFactory: ViewControllerFactory {
     private let diContainer: AppDIContainer
+    private let pushNotificationPermissionService: PushNotificationPermissionService = DefaultPushNotificationPermissionService()
+    private lazy var notificationSettingViewModel = diContainer.makeNotificationSettingViewModel()
+    private lazy var pushNotificationPermissionCoordinator = PushNotificationPermissionCoordinator(viewModel: notificationSettingViewModel,
+                                                                                                    permissionService: pushNotificationPermissionService)
     
     init(diContainer: AppDIContainer = .shared) {
         self.diContainer = diContainer
@@ -60,6 +65,10 @@ final class DefaultViewControllerFactory: ViewControllerFactory {
     func makePotiTabBar() -> PotiTabBar {
         PotiTabBar(factory: self)
     }
+
+    func makePushNotificationPermissionCoordinator() -> PushNotificationPermissionCoordinator {
+        pushNotificationPermissionCoordinator
+    }
     
     @MainActor func makeHomeViewController() -> HomeViewController {
         HomeViewController(
@@ -72,7 +81,8 @@ final class DefaultViewControllerFactory: ViewControllerFactory {
     }
 
     func makeNotificationSettingViewController() -> NotificationSettingViewController {
-        NotificationSettingViewController(viewModel: diContainer.makeNotificationSettingViewModel())
+        NotificationSettingViewController(viewModel: notificationSettingViewModel,
+                                          pushNotificationPermissionCoordinator: makePushNotificationPermissionCoordinator())
     }
 
     func makeSearchViewController() -> SearchViewController {

--- a/POTI-iOS/POTI-iOS/Presentation/Notification/Coordinator/PushNotificationPermissionCoordinator.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Notification/Coordinator/PushNotificationPermissionCoordinator.swift
@@ -14,6 +14,7 @@ final class PushNotificationPermissionCoordinator {
     private let viewModel: NotificationSettingViewModel
     private let permissionService: PushNotificationPermissionService
     private var isWaitingForSystemSettings = false
+    private var pendingPermissionAllowedAction: (() -> Void)?
     
     // MARK: - Initializer
     
@@ -31,38 +32,46 @@ final class PushNotificationPermissionCoordinator {
     
     // MARK: - Private Methods
     
-    private func requestSystemPermission() {
+    private func requestSystemPermission(whenPermissionAllowed: @escaping () -> Void) {
         Task { [weak self] in
             guard let self else { return }
             let result = await permissionService.requestPermissionOrOpenSettings()
-            await handlePermissionResult(result)
+            await handlePermissionResult(result, whenPermissionAllowed: whenPermissionAllowed)
         }
     }
     
     @MainActor
-    private func handlePermissionResult(_ result: PushNotificationPermissionResult) {
+    private func handlePermissionResult(_ result: PushNotificationPermissionResult,
+                                        whenPermissionAllowed: @escaping () -> Void) {
         switch result {
         case .granted:
-            viewModel.action(.setAllNotifications(isEnabled: true))
+            whenPermissionAllowed()
         case .denied:
             viewModel.action(.setAllNotifications(isEnabled: false))
         case .openedSettings:
             isWaitingForSystemSettings = true
+            pendingPermissionAllowedAction = whenPermissionAllowed
             viewModel.action(.setAllNotifications(isEnabled: false))
         }
     }
-    
-    // MARK: - Public Methods
-    
-    func showPermissionModal(in view: UIView) {
+
+    private func showPermissionModal(in view: UIView, whenPermissionAllowed: @escaping () -> Void) {
         let modalView = PushNotificationPermissionModalView()
         modalView.onTapAllow = { [weak self] in
-            self?.requestSystemPermission()
+            self?.requestSystemPermission(whenPermissionAllowed: whenPermissionAllowed)
         }
         modalView.onTapLater = { [weak self] in
             self?.viewModel.action(.setAllNotifications(isEnabled: false))
         }
         modalView.show(in: view)
+    }
+
+    // MARK: - Public Methods
+
+    func showPermissionModal(in view: UIView) {
+        showPermissionModal(in: view) { [weak self] in
+            self?.viewModel.action(.setAllNotifications(isEnabled: true))
+        }
     }
     
     func handleEnablingNotification(in view: UIView, whenPermissionAllowed: @escaping () -> Void) {
@@ -72,7 +81,9 @@ final class PushNotificationPermissionCoordinator {
             if await permissionService.isPermissionAllowed() {
                 await MainActor.run { whenPermissionAllowed() }
             } else {
-                await MainActor.run { self.showPermissionModal(in: view) }
+                await MainActor.run {
+                    self.showPermissionModal(in: view, whenPermissionAllowed: whenPermissionAllowed)
+                }
             }
         }
     }
@@ -87,7 +98,12 @@ final class PushNotificationPermissionCoordinator {
             guard let self else { return }
             let isAllowed = await permissionService.isPermissionAllowed()
             await MainActor.run {
-                self.viewModel.action(.setAllNotifications(isEnabled: isAllowed))
+                if isAllowed {
+                    self.pendingPermissionAllowedAction?()
+                } else {
+                    self.viewModel.action(.setAllNotifications(isEnabled: false))
+                }
+                self.pendingPermissionAllowedAction = nil
             }
         }
     }

--- a/POTI-iOS/POTI-iOS/Presentation/Notification/Coordinator/PushNotificationPermissionCoordinator.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Notification/Coordinator/PushNotificationPermissionCoordinator.swift
@@ -1,0 +1,94 @@
+//
+//  PushNotificationPermissionCoordinator.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/28/26.
+//
+
+import UIKit
+
+final class PushNotificationPermissionCoordinator {
+    
+    // MARK: - Properties
+    
+    private let viewModel: NotificationSettingViewModel
+    private let permissionService: PushNotificationPermissionService
+    private var isWaitingForSystemSettings = false
+    
+    // MARK: - Initializer
+    
+    init(viewModel: NotificationSettingViewModel, permissionService: PushNotificationPermissionService) {
+        self.viewModel = viewModel
+        self.permissionService = permissionService
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive),
+                                               name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func requestSystemPermission() {
+        Task { [weak self] in
+            guard let self else { return }
+            let result = await permissionService.requestPermissionOrOpenSettings()
+            await handlePermissionResult(result)
+        }
+    }
+    
+    @MainActor
+    private func handlePermissionResult(_ result: PushNotificationPermissionResult) {
+        switch result {
+        case .granted:
+            viewModel.action(.setAllNotifications(isEnabled: true))
+        case .denied:
+            viewModel.action(.setAllNotifications(isEnabled: false))
+        case .openedSettings:
+            isWaitingForSystemSettings = true
+            viewModel.action(.setAllNotifications(isEnabled: false))
+        }
+    }
+    
+    // MARK: - Public Methods
+    
+    func showPermissionModal(in view: UIView) {
+        let modalView = PushNotificationPermissionModalView()
+        modalView.onTapAllow = { [weak self] in
+            self?.requestSystemPermission()
+        }
+        modalView.onTapLater = { [weak self] in
+            self?.viewModel.action(.setAllNotifications(isEnabled: false))
+        }
+        modalView.show(in: view)
+    }
+    
+    func handleEnablingNotification(in view: UIView, whenPermissionAllowed: @escaping () -> Void) {
+        Task { [weak self] in
+            guard let self else { return }
+            
+            if await permissionService.isPermissionAllowed() {
+                await MainActor.run { whenPermissionAllowed() }
+            } else {
+                await MainActor.run { self.showPermissionModal(in: view) }
+            }
+        }
+    }
+    
+    // MARK: - Action
+    
+    @objc private func applicationDidBecomeActive() {
+        guard isWaitingForSystemSettings else { return }
+        isWaitingForSystemSettings = false
+        
+        Task { [weak self] in
+            guard let self else { return }
+            let isAllowed = await permissionService.isPermissionAllowed()
+            await MainActor.run {
+                self.viewModel.action(.setAllNotifications(isEnabled: isAllowed))
+            }
+        }
+    }
+}

--- a/POTI-iOS/POTI-iOS/Presentation/Notification/Model/NotificationItem.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Notification/Model/NotificationItem.swift
@@ -5,38 +5,21 @@
 //  Created by soomin on 8/27/26.
 //
 
+import Foundation
+
 struct NotificationItem {
+    let id: Int
     let title: String
     let content: String
     let time: String
+    let type: String
+    let deeplink: String?
     var isRead: Bool
 }
 
-extension NotificationItem {
-    static let mockData: [NotificationItem] = [
-        NotificationItem(
-            title: "배송 시작",
-            content: "아이브 메이크스타 거래건 배송이 시작되었어요",
-            time: "3시간 전",
-            isRead: false
-        ),
-        NotificationItem(
-            title: "배송 시작",
-            content: "아이브 메이크스타 거래건 배송이 시작되었어요",
-            time: "3시간 전",
-            isRead: true
-        ),
-        NotificationItem(
-            title: "배송 시작",
-            content: "아이브 메이크스타 거래건 배송이 시작되었어요",
-            time: "3시간 전",
-            isRead: true
-        ),
-        NotificationItem(
-            title: "배송 시작",
-            content: "아이브 메이크스타 거래건 배송이 시작되었어요",
-            time: "3시간 전",
-            isRead: true
-        )
-    ]
+extension NotificationEntity {
+    func toNotificationItem(now: Date = Date()) -> NotificationItem {
+        return NotificationItem(id: id, title: title, content: body, time: createdAt.toRelativeTime(now: now),
+                                type: type, deeplink: deeplink, isRead: isRead)
+    }
 }

--- a/POTI-iOS/POTI-iOS/Presentation/Notification/View/NotificationSettingView.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Notification/View/NotificationSettingView.swift
@@ -19,8 +19,10 @@ final class NotificationSettingView: BaseView {
 
     private let tradeTitleLabel = UILabel()
     private let tradeDescriptionLabel = UILabel()
+    private let tradeStackView = UIStackView()
     private let eventTitleLabel = UILabel()
     private let eventDescriptionLabel = UILabel()
+    private let eventStackView = UIStackView()
 
     // MARK: - Custom Methods
 
@@ -39,6 +41,12 @@ final class NotificationSettingView: BaseView {
             $0.text = "분철 모집/참여 거래 알림"
         }
 
+        tradeStackView.do {
+            $0.axis = .vertical
+            $0.spacing = 4
+            $0.alignment = .leading
+        }
+
         eventTitleLabel.do {
             $0.font = PotiFontManager.body16sb.font
             $0.textColor = .potiBlack
@@ -50,45 +58,45 @@ final class NotificationSettingView: BaseView {
             $0.textColor = .gray800
             $0.text = "광고성 정보 수신 및 마케팅 알림"
         }
+
+        eventStackView.do {
+            $0.axis = .vertical
+            $0.spacing = 4
+            $0.alignment = .leading
+        }
     }
 
     override func setUI() {
-        addSubviews(tradeTitleLabel, tradeDescriptionLabel, tradeToggle, eventTitleLabel, eventDescriptionLabel, eventToggle)
+        tradeStackView.addArrangedSubviews(tradeTitleLabel, tradeDescriptionLabel)
+        eventStackView.addArrangedSubviews(eventTitleLabel, eventDescriptionLabel)
+        addSubviews(tradeStackView, tradeToggle, eventStackView, eventToggle)
     }
 
     override func setLayout() {
-        tradeTitleLabel.snp.makeConstraints {
+        tradeStackView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(15)
             $0.leading.equalToSuperview().inset(16)
-        }
-
-        tradeDescriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(tradeTitleLabel.snp.bottom).offset(4)
-            $0.leading.equalTo(tradeTitleLabel)
+            $0.trailing.lessThanOrEqualTo(tradeToggle.snp.leading).offset(-16)
         }
 
         tradeToggle.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
-            $0.centerY.equalTo(tradeTitleLabel.snp.bottom).offset(11.5)
+            $0.centerY.equalTo(tradeStackView)
         }
 
-        eventTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(tradeDescriptionLabel.snp.bottom).offset(31)
-            $0.leading.equalTo(tradeTitleLabel)
-        }
-
-        eventDescriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(eventTitleLabel.snp.bottom).offset(4)
-            $0.leading.equalTo(eventTitleLabel)
+        eventStackView.snp.makeConstraints {
+            $0.top.equalTo(tradeStackView.snp.bottom).offset(31)
+            $0.leading.equalTo(tradeStackView)
+            $0.trailing.lessThanOrEqualTo(eventToggle.snp.leading).offset(-16)
         }
 
         eventToggle.snp.makeConstraints {
             $0.trailing.equalTo(tradeToggle)
-            $0.centerY.equalTo(eventTitleLabel.snp.bottom).offset(11.5)
+            $0.centerY.equalTo(eventStackView)
         }
     }
 
-    // MARK: - Public Methods
+    // MARK: - Public Method
 
     func configure(isTradeNotificationOn: Bool, isEventNotificationOn: Bool) {
         tradeToggle.setOn(isTradeNotificationOn, animated: false)

--- a/POTI-iOS/POTI-iOS/Presentation/Notification/ViewController/NotificationSettingViewController.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Notification/ViewController/NotificationSettingViewController.swift
@@ -11,13 +11,15 @@ import Combine
 
 final class NotificationSettingViewController: BaseViewController<NotificationSettingViewModel>, NavigationConfigurable {
     
-    // MARK: - Property
+    // MARK: - Properties
     
     private let rootView = NotificationSettingView()
+    private let pushNotificationPermissionCoordinator: PushNotificationPermissionCoordinator
     
     // MARK: - Initializer
     
-    override init(viewModel: NotificationSettingViewModel) {
+    init(viewModel: NotificationSettingViewModel, pushNotificationPermissionCoordinator: PushNotificationPermissionCoordinator) {
+        self.pushNotificationPermissionCoordinator = pushNotificationPermissionCoordinator
         super.init(viewModel: viewModel)
     }
     
@@ -62,15 +64,9 @@ final class NotificationSettingViewController: BaseViewController<NotificationSe
         )
     }
     
-    private func showPushNotificationPermissionModal() {
-        let modalView = PushNotificationPermissionModalView()
-        modalView.onTapAllow = { [weak self] in
-            self?.viewModel.action(.setAllNotifications(isEnabled: true))
-        }
-        modalView.onTapLater = { [weak self] in
-            self?.viewModel.action(.setAllNotifications(isEnabled: false))
-        }
-        modalView.show(in: navigationController?.view ?? view)
+    private func handleEnablingNotification(whenPermissionAllowed: @escaping () -> Void) {
+        pushNotificationPermissionCoordinator.handleEnablingNotification(in: navigationController?.view ?? view,
+                                                                         whenPermissionAllowed: whenPermissionAllowed)
     }
     
     // MARK: - Public Method
@@ -86,7 +82,9 @@ final class NotificationSettingViewController: BaseViewController<NotificationSe
             viewModel.action(.didToggleTradeNotification)
         } else {
             resetToggleState()
-            showPushNotificationPermissionModal()
+            handleEnablingNotification { [weak self] in
+                self?.viewModel.action(.didToggleTradeNotification)
+            }
         }
     }
     
@@ -95,7 +93,9 @@ final class NotificationSettingViewController: BaseViewController<NotificationSe
             viewModel.action(.didToggleEventNotification)
         } else {
             resetToggleState()
-            showPushNotificationPermissionModal()
+            handleEnablingNotification { [weak self] in
+                self?.viewModel.action(.didToggleEventNotification)
+            }
         }
     }
 }

--- a/POTI-iOS/POTI-iOS/Presentation/Notification/ViewController/NotificationViewController.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Notification/ViewController/NotificationViewController.swift
@@ -15,6 +15,7 @@ final class NotificationViewController: BaseViewController<NotificationViewModel
 
     private let rootView = NotificationView()
     private let factory: ViewControllerFactory
+    private lazy var deepLinkRouter = DeepLinkRouter(factory: factory)
 
     // MARK: - Initializer
 
@@ -59,11 +60,29 @@ final class NotificationViewController: BaseViewController<NotificationViewModel
                 rootView.notificationTableView.reloadData()
             }
             .store(in: &cancellables)
+
+        viewModel.output.deepLink
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.openDeepLink($0) }
+            .store(in: &cancellables)
     }
 
     override func settingButtonTapped() {
         let notificationSettingViewController = factory.makeNotificationSettingViewController()
         navigationController?.pushViewController(notificationSettingViewController, animated: true)
+    }
+
+    // MARK: - Private Method
+
+    private func openDeepLink(_ deepLink: String) {
+        do {
+            guard let url = URL(string: deepLink) else { return }
+            let parser = DeepLinkParser(allowedHost: try AppConfig.deepLinkHost())
+            guard let route = parser.parse(url) else { return }
+            deepLinkRouter.route(to: route, from: view.window?.rootViewController)
+        } catch {
+            PotiLogger.error(error)
+        }
     }
     
     // MARK: - Public Method
@@ -102,5 +121,11 @@ extension NotificationViewController: UITableViewDataSource {
 extension NotificationViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         viewModel.action(.didTapNotification(index: indexPath.row))
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let threshold = scrollView.contentSize.height - scrollView.bounds.height - 100
+        guard scrollView.contentOffset.y > threshold else { return }
+        viewModel.action(.loadNextPage)
     }
 }

--- a/POTI-iOS/POTI-iOS/Presentation/Notification/ViewModel/NotificationSettingViewModel.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Notification/ViewModel/NotificationSettingViewModel.swift
@@ -26,8 +26,12 @@ final class NotificationSettingViewModel: BaseViewModelType {
 
     // MARK: - Properties
 
-    private(set) var isTradeNotificationOn: Bool
-    private(set) var isEventNotificationOn: Bool
+    private let fetchNotificationSettingsUseCase: FetchNotificationSettingsUseCase
+    private let updateNotificationSettingsUseCase: UpdateNotificationSettingsUseCase
+    private var isUpdating = false
+
+    private(set) var isTradeNotificationOn = false
+    private(set) var isEventNotificationOn = false
     let output: Output
 
     // MARK: - Subject
@@ -36,9 +40,10 @@ final class NotificationSettingViewModel: BaseViewModelType {
 
     // MARK: - Initializer
 
-    init(isTradeNotificationOn: Bool = false, isEventNotificationOn: Bool = false) {
-        self.isTradeNotificationOn = isTradeNotificationOn
-        self.isEventNotificationOn = isEventNotificationOn
+    init(fetchNotificationSettingsUseCase: FetchNotificationSettingsUseCase,
+         updateNotificationSettingsUseCase: UpdateNotificationSettingsUseCase) {
+        self.fetchNotificationSettingsUseCase = fetchNotificationSettingsUseCase
+        self.updateNotificationSettingsUseCase = updateNotificationSettingsUseCase
         self.output = Output(reloadData: reloadDataSubject.eraseToAnyPublisher())
     }
 
@@ -47,17 +52,56 @@ final class NotificationSettingViewModel: BaseViewModelType {
     func action(_ trigger: Input) {
         switch trigger {
         case .viewDidLoad:
-            reloadDataSubject.send(())
+            fetchSettings()
         case .didToggleTradeNotification:
-            isTradeNotificationOn.toggle()
-            reloadDataSubject.send(())
+            updateSettings(tradeNotificationEnabled: !isTradeNotificationOn, eventNotificationEnabled: isEventNotificationOn)
         case .didToggleEventNotification:
-            isEventNotificationOn.toggle()
-            reloadDataSubject.send(())
+            updateSettings(tradeNotificationEnabled: isTradeNotificationOn, eventNotificationEnabled: !isEventNotificationOn)
         case .setAllNotifications(let isEnabled):
-            isTradeNotificationOn = isEnabled
-            isEventNotificationOn = isEnabled
-            reloadDataSubject.send(())
+            updateSettings(tradeNotificationEnabled: isEnabled, eventNotificationEnabled: isEnabled)
         }
+    }
+
+    // MARK: - Private Methods
+
+    private func fetchSettings() {
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let settings = try await fetchNotificationSettingsUseCase.execute()
+                apply(settings)
+            } catch {
+                PotiLogger.error(error)
+            }
+        }
+    }
+
+    private func updateSettings(tradeNotificationEnabled: Bool, eventNotificationEnabled: Bool) {
+        guard !isUpdating else {
+            reloadDataSubject.send(())
+            return
+        }
+        isUpdating = true
+
+        Task { [weak self] in
+            guard let self else { return }
+            defer { isUpdating = false }
+
+            do {
+                let settings = try await updateNotificationSettingsUseCase.execute(tradeNotificationEnabled: tradeNotificationEnabled,
+                                                                                   eventNotificationEnabled: eventNotificationEnabled)
+                apply(settings)
+            } catch {
+                reloadDataSubject.send(())
+                PotiLogger.error(error)
+            }
+        }
+    }
+
+    private func apply(_ settings: NotificationSettingsEntity) {
+        isTradeNotificationOn = settings.isTradeNotificationEnabled
+        isEventNotificationOn = settings.isEventNotificationEnabled
+        reloadDataSubject.send(())
     }
 }

--- a/POTI-iOS/POTI-iOS/Presentation/Notification/ViewModel/NotificationViewModel.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Notification/ViewModel/NotificationViewModel.swift
@@ -13,6 +13,7 @@ final class NotificationViewModel: BaseViewModelType {
 
     enum Input {
         case viewDidLoad
+        case loadNextPage
         case didTapNotification(index: Int)
         case didTapReadAll
     }
@@ -21,11 +22,21 @@ final class NotificationViewModel: BaseViewModelType {
 
     struct Output {
         let reloadData: AnyPublisher<Void, Never>
+        let deepLink: AnyPublisher<String, Never>
     }
 
     // MARK: - Properties
 
-    private(set) var notifications: [NotificationItem]
+    private let fetchNotificationsUseCase: FetchNotificationsUseCase
+    private let readNotificationUseCase: ReadNotificationUseCase
+    private let readAllNotificationsUseCase: ReadAllNotificationsUseCase
+
+    private(set) var notifications: [NotificationItem] = []
+    private var currentPage = 0
+    private var hasNextPage = true
+    private var isFetching = false
+    private var isReadingAll = false
+
     let output: Output
 
     var hasUnreadNotification: Bool {
@@ -35,12 +46,16 @@ final class NotificationViewModel: BaseViewModelType {
     // MARK: - Subject
 
     private let reloadDataSubject = PassthroughSubject<Void, Never>()
+    private let deepLinkSubject = PassthroughSubject<String, Never>()
 
     // MARK: - Initializer
 
-    init(notifications: [NotificationItem] = []) {
-        self.notifications = notifications
-        self.output = Output(reloadData: reloadDataSubject.eraseToAnyPublisher())
+    init(fetchNotificationsUseCase: FetchNotificationsUseCase, readNotificationUseCase: ReadNotificationUseCase,
+         readAllNotificationsUseCase: ReadAllNotificationsUseCase) {
+        self.fetchNotificationsUseCase = fetchNotificationsUseCase
+        self.readNotificationUseCase = readNotificationUseCase
+        self.readAllNotificationsUseCase = readAllNotificationsUseCase
+        self.output = Output(reloadData: reloadDataSubject.eraseToAnyPublisher(), deepLink: deepLinkSubject.eraseToAnyPublisher())
     }
 
     // MARK: - Action
@@ -48,7 +63,9 @@ final class NotificationViewModel: BaseViewModelType {
     func action(_ trigger: Input) {
         switch trigger {
         case .viewDidLoad:
-            reloadDataSubject.send(())
+            fetchNotifications(isFirstPage: true)
+        case .loadNextPage:
+            fetchNotifications(isFirstPage: false)
         case .didTapNotification(let index):
             readNotification(at: index)
         case .didTapReadAll:
@@ -58,17 +75,81 @@ final class NotificationViewModel: BaseViewModelType {
 
     // MARK: - Private Methods
 
+    private func fetchNotifications(isFirstPage: Bool) {
+        guard !isFetching && (isFirstPage || hasNextPage) else { return }
+
+        isFetching = true
+        let requestedPage = isFirstPage ? 0 : currentPage
+
+        Task { [weak self] in
+            guard let self else { return }
+            defer { isFetching = false }
+
+            do {
+                let page = try await fetchNotificationsUseCase.execute(page: requestedPage)
+                let newItems = page.notifications.map { $0.toNotificationItem() }
+
+                if isFirstPage {
+                    notifications = newItems
+                } else {
+                    notifications.append(contentsOf: newItems)
+                }
+
+                currentPage = page.currentPage + 1
+                hasNextPage = page.hasNext
+                reloadDataSubject.send(())
+            } catch {
+                PotiLogger.error(error)
+            }
+        }
+    }
+
     private func readNotification(at index: Int) {
-        guard notifications.indices.contains(index), !notifications[index].isRead else { return }
-        notifications[index].isRead = true
-        reloadDataSubject.send(())
+        guard notifications.indices.contains(index) else { return }
+
+        let notification = notifications[index]
+        guard !notification.isRead else {
+            sendDeepLinkIfNeeded(notification.deeplink)
+            return
+        }
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                try await readNotificationUseCase.execute(notificationId: notification.id)
+                guard let updatedIndex = notifications.firstIndex(where: { $0.id == notification.id }) else { return }
+                notifications[updatedIndex].isRead = true
+                reloadDataSubject.send(())
+                sendDeepLinkIfNeeded(notification.deeplink)
+            } catch {
+                PotiLogger.error(error)
+            }
+        }
+    }
+
+    private func sendDeepLinkIfNeeded(_ deepLink: String?) {
+        guard let deepLink, !deepLink.isBlank else { return }
+        deepLinkSubject.send(deepLink)
     }
 
     private func readAllNotifications() {
-        guard hasUnreadNotification else { return }
-        for index in notifications.indices {
-            notifications[index].isRead = true
+        guard hasUnreadNotification, !isReadingAll else { return }
+        isReadingAll = true
+
+        Task { [weak self] in
+            guard let self else { return }
+            defer { isReadingAll = false }
+
+            do {
+                try await readAllNotificationsUseCase.execute()
+                for index in notifications.indices {
+                    notifications[index].isRead = true
+                }
+                reloadDataSubject.send(())
+            } catch {
+                PotiLogger.error(error)
+            }
         }
-        reloadDataSubject.send(())
     }
 }

--- a/POTI-iOS/POTI-iOS/Presentation/Onboarding/ViewController/SelectFavoriteIdolGroupViewController.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Onboarding/ViewController/SelectFavoriteIdolGroupViewController.swift
@@ -99,6 +99,11 @@ extension SelectFavoriteIdolGroupViewController {
         }
         
         sceneDelegate.switchRootViewController(to: tabBar)
+
+        let permissionCoordinator = factory.makePushNotificationPermissionCoordinator()
+        DispatchQueue.main.async {
+            permissionCoordinator.showPermissionModal(in: tabBar.view)
+        }
     }
 }
 

--- a/POTI-iOS/POTI-iOS/Presentation/PotDetail/View/RowView.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/PotDetail/View/RowView.swift
@@ -39,9 +39,9 @@ final class RowView: UIView {
         }
 
         valueStackView.do {
-            $0.axis = .horizontal
+            $0.axis = .vertical
             $0.spacing = 8
-            $0.alignment = .center
+            $0.alignment = .leading
         }
     }
 
@@ -51,14 +51,15 @@ final class RowView: UIView {
 
     private func setLayout() {
         titleLabel.snp.makeConstraints {
-            $0.leading.top.bottom.equalToSuperview()
+            $0.leading.top.equalToSuperview()
+            $0.bottom.lessThanOrEqualToSuperview()
             $0.width.equalTo(77)
         }
 
         valueStackView.snp.makeConstraints {
             $0.leading.equalTo(titleLabel.snp.trailing).offset(12)
             $0.trailing.lessThanOrEqualToSuperview()
-            $0.centerY.equalTo(titleLabel)
+            $0.verticalEdges.equalToSuperview()
         }
     }
 
@@ -75,14 +76,18 @@ final class RowView: UIView {
         titleLabel.text = title
         valueStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
-        for (index, value) in values.enumerated() {
-            let label = createValueLabel(with: value)
-            valueStackView.addArrangedSubview(label)
+        values.chunked(into: 2).forEach { rowValues in
+            let rowStackView = createRowStackView()
 
-            if index < values.count - 1 {
-                let divider = createVerticalDivider()
-                valueStackView.addArrangedSubview(divider)
+            for (index, value) in rowValues.enumerated() {
+                rowStackView.addArrangedSubview(createValueLabel(with: value))
+
+                if index < rowValues.count - 1 {
+                    rowStackView.addArrangedSubview(createVerticalDivider())
+                }
             }
+
+            valueStackView.addArrangedSubview(rowStackView)
         }
     }
 
@@ -101,6 +106,20 @@ final class RowView: UIView {
         }
     }
 
+    private func createRowStackView() -> UIStackView {
+        let stackView = UIStackView().then {
+            $0.axis = .horizontal
+            $0.spacing = 8
+            $0.alignment = .center
+        }
+
+        stackView.snp.makeConstraints {
+            $0.height.equalTo(21)
+        }
+
+        return stackView
+    }
+
     private func createVerticalDivider() -> UIView {
         return UIView().then {
             $0.backgroundColor = .gray800
@@ -110,6 +129,14 @@ final class RowView: UIView {
                 make.width.equalTo(1)
                 make.height.equalTo(21)
             }
+        }
+    }
+}
+
+private extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map {
+            Array(self[$0..<Swift.min($0 + size, count)])
         }
     }
 }

--- a/POTI-iOS/POTI-iOS/Presentation/Register/Model/ProductRegistrationCompletion.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Register/Model/ProductRegistrationCompletion.swift
@@ -1,0 +1,13 @@
+//
+//  ProductRegistrationCompletion.swift
+//  POTI-iOS
+//
+//  Created by soomin on 8/27/26.
+//
+
+struct ProductRegistrationCompletion {
+    let postId: Int
+    let productTitle: String
+    let artistId: Int
+    let artistName: String
+}

--- a/POTI-iOS/POTI-iOS/Presentation/Register/ViewController/RegisterViewController.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Register/ViewController/RegisterViewController.swift
@@ -222,7 +222,7 @@ final class RegisterViewController: BaseViewController<RegisterViewModel>, Navig
     private func bindRegistrationResult() {
         viewModel.output.registrationCompleted
             .receive(on: RunLoop.main)
-            .sink { [weak self] in self?.showRegistrationNotice(postId: $0) }
+            .sink { [weak self] in self?.showRegistrationNotice(completion: $0) }
             .store(in: &cancellables)
 
         viewModel.output.registrationFailed
@@ -318,16 +318,23 @@ final class RegisterViewController: BaseViewController<RegisterViewModel>, Navig
         viewModel.action(.setArtist(artist))
     }
 
-    private func showRegistrationNotice(postId: Int) {
+    private func showRegistrationNotice(completion: ProductRegistrationCompletion) {
         let noticeView = NoticeModalView(type: .register)
-        noticeView.onTapConfirm = { [weak self] in self?.replaceWithProductDetail(postId: postId) }
+        noticeView.onTapConfirm = { [weak self] in self?.replaceWithProductDetail(completion: completion) }
         noticeView.show(in: navigationController?.view ?? view)
     }
 
-    private func replaceWithProductDetail(postId: Int) {
-        let productDetailViewController = factory.makePotDetailViewController(postId: postId)
+    private func replaceWithProductDetail(completion: ProductRegistrationCompletion) {
+        let potListViewController = factory.makePotListViewController(title: completion.productTitle,
+                                                                      artistId: completion.artistId, artistName: completion.artistName)
+        let productDetailViewController = factory.makePotDetailViewController(postId: completion.postId)
+
         if let navigationController {
-            navigationController.setViewControllers([productDetailViewController], animated: true)
+            var previousViewControllers = navigationController.viewControllers.filter { $0 !== self }
+            if previousViewControllers.last is PotListViewController {
+                previousViewControllers.removeLast()
+            }
+            navigationController.setViewControllers(previousViewControllers + [potListViewController, productDetailViewController], animated: true)
         } else {
             present(productDetailViewController, animated: true)
         }

--- a/POTI-iOS/POTI-iOS/Presentation/Register/ViewModel/RegisterViewModel.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Register/ViewModel/RegisterViewModel.swift
@@ -44,7 +44,7 @@ final class RegisterViewModel: BaseViewModelType {
         let shippingSetting: AnyPublisher<ShippingSettingViewState, Never>
         let deadlinePickerRequest: AnyPublisher<Date, Never>
         let deadline: AnyPublisher<Date, Never>
-        let registrationCompleted: AnyPublisher<Int, Never>
+        let registrationCompleted: AnyPublisher<ProductRegistrationCompletion, Never>
         let registrationFailed: AnyPublisher<String, Never>
     }
 
@@ -69,7 +69,7 @@ final class RegisterViewModel: BaseViewModelType {
 
     // MARK: - Subjects
 
-    private let registrationCompletedSubject = PassthroughSubject<Int, Never>()
+    private let registrationCompletedSubject = PassthroughSubject<ProductRegistrationCompletion, Never>()
     private let registrationFailedSubject = PassthroughSubject<String, Never>()
     private let productTypesSubject = CurrentValueSubject<[String], Never>([])
     private let optimizedImagesSubject = CurrentValueSubject<[OptimizedImage], Never>([])
@@ -298,15 +298,17 @@ final class RegisterViewModel: BaseViewModelType {
         fieldErrorsSubject.send(errors)
         sendMemberSettingState()
         sendShippingSettingState()
-        guard !errors.hasError, let artistId = selectedArtist?.id else { return }
+        guard !errors.hasError, let selectedArtist else { return }
 
         Task { [weak self] in
             guard let self else { return }
             do {
                 let imagePaths = try await uploadImages()
-                let entity = makeRegisterPostEntity(artistId: artistId, imagePaths: imagePaths)
+                let entity = makeRegisterPostEntity(artistId: selectedArtist.id, imagePaths: imagePaths)
                 let response = try await registerPostUseCase.execute(entity)
-                await MainActor.run { self.registrationCompletedSubject.send(response.postId) }
+                let completion = ProductRegistrationCompletion(postId: response.postId, productTitle: self.formState.productType,
+                                                               artistId: selectedArtist.id, artistName: selectedArtist.name)
+                await MainActor.run { self.registrationCompletedSubject.send(completion) }
             } catch {
                 PotiLogger.error(error)
                 await MainActor.run { self.registrationFailedSubject.send("등록에 실패했어요") }


### PR DESCRIPTION
## 🌴 작업한 브랜치

- Resolved: #186 

## ✅ 작업한 내용
### 알림 목록 API 연동
알림 목록을 최신순으로 조회하는 API를 연동했습니다.
알림을 선택하면 딥링크로 연결되고, 해당 알림은 읽음 처리됩니다.

(현재 딥링크 URL은 서버에서 수정 중!! 수정되면 알림 눌렀을 때 알림 관련 글로 화면 이동 잘 될 예정)

### 알림 설정 API 연동 및 시스템 권한
거래 알림과 이벤트/혜택 알림 설정을 조회하고 변경하는 API를 연동했습니다.

설정 로직은 아래와 같습니다.
```
- 안내 모달에서 `푸시 알림 허용`을 선택하면 iOS 시스템 알림 권한을 요청

- 시스템 권한까지 허용한 경우 거래 알림과 이벤트/혜택 알림을 모두 ON으로 설정

- 시스템 권한을 거절하거나 `나중에`를 선택한 경우 두 알림을 모두 OFF로 설정

- 시스템 권한을 이미 거절한 경우 아이폰 설정 앱으로 이동

- 설정 앱에서 설정하고 앱으로 돌아오면 시스템 권한을 다시 확인하고 토글 상태 동기화
```
### 기타 수정
- 배송 옵션 레이아웃 수정
- 분철팟 등록 후 상세 화면에서 뒤로가기를 누르면 굿즈별 분철팟 목록이 나오도록 수정


## ❗️PR Point
앱 내부의 알림 수신 설정과 iOS 시스템 알림 권한은 서로 다른 상태이기 때문에 별도로 관리했습니다. 
실제 푸시 알림을 전달할 수 있도록 시스템 권한이 허용된 경우에만 알림 설정을 ON으로 변경합니다.


## 📷 Screenshots  
- **알림 목록 조회**

https://github.com/user-attachments/assets/df9e4930-62ba-4069-bd4e-d52f7b576df5

- **알림 읽음 처리**

https://github.com/user-attachments/assets/6c6f2c6b-e01e-4758-94e3-cb285204faea

- **푸쉬 알림 및 시스템 권한 허용 (실제 흐름은 온보딩 완료 후 모달이 뜸)**

https://github.com/user-attachments/assets/9a05b061-ce01-4076-84fd-8c1ca833702c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 알림 목록을 서버에서 불러오고, 페이지 추가 로딩 및 개별·전체 읽음 처리를 지원합니다.
  - 알림 설정을 조회하고 거래·이벤트 알림을 변경할 수 있습니다.
  - 알림 권한 요청과 기기 설정 화면 이동을 지원합니다.
  - 알림 선택 시 관련 딥링크로 이동합니다.
  - 상품 등록 완료 후 상품 목록과 상세 화면으로 자연스럽게 이동합니다.

- **UI 개선**
  - 알림 설정 토글과 일부 상세 정보 레이아웃을 개선했습니다.
  - 알림 시간이 상대 시간 또는 날짜 형식으로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->