### PR TITLE
[refactor] #207 - 모집 인원 없을 때 삭제 버튼 추가

### DIFF
--- a/POTI-iOS/POTI-iOS/Application/AppDIContainer.swift
+++ b/POTI-iOS/POTI-iOS/Application/AppDIContainer.swift
@@ -156,6 +156,10 @@ final class AppDIContainer {
         DefaultFetchPotOptionsUseCase(repository: makePostRepository())
     }
 
+    private func makeDeletePostUseCase() -> DeletePostUseCase {
+        DefaultDeletePostUseCase(repository: makePostRepository())
+    }
+
     private func makeSearchPostsUseCase() -> SearchPostsUseCase {
         DefaultSearchPostsUseCase(repository: makeSearchRepository())
     }
@@ -341,7 +345,11 @@ final class AppDIContainer {
     }
 
     func makeRecruitDetailViewModel(postId: Int) -> RecruitDetailViewModel {
-        RecruitDetailViewModel(postId: postId, postsSaleUseCase: makePostsSaleUseCase())
+        RecruitDetailViewModel(
+            postId: postId,
+            postsSaleUseCase: makePostsSaleUseCase(),
+            deletePostUseCase: makeDeletePostUseCase()
+        )
     }
 
     func makeManageViewModel(postId: Int) -> ParticipantManageViewModel {

--- a/POTI-iOS/POTI-iOS/Data/Network/Post/PostAPI.swift
+++ b/POTI-iOS/POTI-iOS/Data/Network/Post/PostAPI.swift
@@ -13,6 +13,7 @@ enum PostAPI: BaseTargetType {
     case fetchPotList(title: String, artistId: Int, memberIds: [Int]?, sort: String, page: Int)
     case fetchPotDetail(postId: Int)
     case fetchPotOptions(postId: Int)
+    case deletePost(postId: Int)
 
     var path: String {
         switch self {
@@ -26,6 +27,8 @@ enum PostAPI: BaseTargetType {
             return "api/v1/posts/pots"
         case .fetchPotOptions(postId: let postId):
             return "/api/v1/posts/\(postId)/options"
+        case .deletePost(let postId):
+            return "/api/v1/posts/\(postId)"
         }
     }
 
@@ -33,12 +36,14 @@ enum PostAPI: BaseTargetType {
         switch self {
         case .fetchPotDetail, .fetchHome, .fetchFeeds, .fetchPotList, .fetchPotOptions:
             return .get
+        case .deletePost:
+            return .delete
         }
     }
 
     var queryParameters: [String: String]? {
         switch self {
-        case .fetchHome, .fetchPotDetail, .fetchPotOptions:
+        case .fetchHome, .fetchPotDetail, .fetchPotOptions, .deletePost:
             return nil
 
         case .fetchFeeds(let artistId, let sort, let page):

--- a/POTI-iOS/POTI-iOS/Data/Repository/DefaultPostRepository.swift
+++ b/POTI-iOS/POTI-iOS/Data/Repository/DefaultPostRepository.swift
@@ -51,4 +51,11 @@ final class DefaultPostRepository: PostInterface {
         )
         return response.toEntity()
     }
+
+    func deletePost(postId: Int) async throws {
+        _ = try await networkService.request(
+            target: PostAPI.deletePost(postId: postId),
+            type: EmptyResponse.self
+        )
+    }
 }

--- a/POTI-iOS/POTI-iOS/Data/Repository/Mock/MockPostRepository.swift
+++ b/POTI-iOS/POTI-iOS/Data/Repository/Mock/MockPostRepository.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 final class MockPostRepository: PostInterface {
+    func deletePost(postId: Int) async throws {}
+
     func fetchHomeData() async throws -> HomeEntity {
         return createMockHomeEntity(mainArtistId: 1, isFallback: false)
     }

--- a/POTI-iOS/POTI-iOS/Domain/Interface/PostInterface.swift
+++ b/POTI-iOS/POTI-iOS/Domain/Interface/PostInterface.swift
@@ -11,4 +11,5 @@ protocol PostInterface {
     func fetchPotListData(title: String, artistId: Int, memberIds: [Int]?, sort: String, page: Int) async throws -> PotListEntity
     func fetchPotDetail(postId: Int) async throws -> PotDetailEntity
     func fetchPotOptions(postId: Int) async throws -> PotOptionsEntity
+    func deletePost(postId: Int) async throws
 }

--- a/POTI-iOS/POTI-iOS/Domain/UseCase/Post/DeletePostUseCase.swift
+++ b/POTI-iOS/POTI-iOS/Domain/UseCase/Post/DeletePostUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  DeletePostUseCase.swift
+//  POTI-iOS
+//
+
+protocol DeletePostUseCase {
+    func execute(postId: Int) async throws
+}
+
+final class DefaultDeletePostUseCase: DeletePostUseCase {
+    private let repository: PostInterface
+
+    init(repository: PostInterface) {
+        self.repository = repository
+    }
+
+    func execute(postId: Int) async throws {
+        try await repository.deletePost(postId: postId)
+    }
+}

--- a/POTI-iOS/POTI-iOS/Presentation/MyPageHistory/ViewController/MyPageHistoryViewController.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/MyPageHistory/ViewController/MyPageHistoryViewController.swift
@@ -56,10 +56,27 @@ final class MyPageHistoryViewController: BaseViewController<MyPageHistoryViewMod
         tabView.updateTabSelection(tab: currentTab)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.action(.refreshRequested)
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        applyInitialTabOffsetIfPossible()
+    }
 
-        guard !hasAppliedInitialTabOffset, view.bounds.width > 0 else { return }
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        applyInitialTabOffsetIfPossible()
+    }
+
+    private func applyInitialTabOffsetIfPossible() {
+        let pageWidth = contentView.scrollView.bounds.width
+        guard !hasAppliedInitialTabOffset,
+              pageWidth > 0,
+              contentView.scrollView.contentSize.width >= pageWidth * 2 else { return }
+
         hasAppliedInitialTabOffset = true
         updateTabSelection(to: currentTab, animated: false)
     }

--- a/POTI-iOS/POTI-iOS/Presentation/MyPageJoin/ViewController/MyPageJoinDetailViewController.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/MyPageJoin/ViewController/MyPageJoinDetailViewController.swift
@@ -36,6 +36,10 @@ final class MyPageJoinDetailViewController: BaseViewController<MyPageJoinViewMod
     
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         viewModel.action(.viewDidLoad)
     }
     

--- a/POTI-iOS/POTI-iOS/Presentation/Recruit/Model/RecruitDetailViewState.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Recruit/Model/RecruitDetailViewState.swift
@@ -13,6 +13,7 @@ struct RecruitDetailViewState {
     let progress: ProgressStatusViewCell.Model
     let participantCount: Int
     let participants: [ParticipantManageViewCell.Model]
+    let canDelete: Bool
 }
 
 struct PotInfoViewState {
@@ -184,7 +185,8 @@ struct RecruitDetailViewStateMapper {
             potInfo: potInfo,
             progress: progress,
             participantCount: entity.totalCount,
-            participants: participants
+            participants: participants,
+            canDelete: entity.participant.isEmpty
         )
     }
 }

--- a/POTI-iOS/POTI-iOS/Presentation/Recruit/Model/RecruitDetailViewState.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Recruit/Model/RecruitDetailViewState.swift
@@ -186,7 +186,7 @@ struct RecruitDetailViewStateMapper {
             progress: progress,
             participantCount: entity.totalCount,
             participants: participants,
-            canDelete: entity.participant.isEmpty
+            canDelete: entity.totalCount == 0
         )
     }
 }

--- a/POTI-iOS/POTI-iOS/Presentation/Recruit/ViewController/ParticipantListTableViewController.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Recruit/ViewController/ParticipantListTableViewController.swift
@@ -35,8 +35,12 @@ final class ParticipantListTableViewController: BaseViewController<ParticipantMa
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewModel.action(.viewDidLoad)
         lastSectionCount = viewModel.participants.count
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.action(.viewDidLoad)
     }
     
     override func setUI() {

--- a/POTI-iOS/POTI-iOS/Presentation/Recruit/ViewController/RecruitDetailViewController.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Recruit/ViewController/RecruitDetailViewController.swift
@@ -93,7 +93,15 @@ class RecruitDetailViewController: BaseViewController<RecruitDetailViewModel>, N
                     style: .backDefault(state.navigationTitle),
                     target: self
                 )
+                self.updateDeleteButton(isVisible: state.canDelete)
                 self.tableView.reloadData()
+            }
+            .store(in: &cancellables)
+
+        viewModel.output.postDeleted
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
             }
             .store(in: &cancellables)
         
@@ -135,6 +143,35 @@ class RecruitDetailViewController: BaseViewController<RecruitDetailViewModel>, N
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .default))
         present(alert, animated: true)
+    }
+
+    private func updateDeleteButton(isVisible: Bool) {
+        guard isVisible else {
+            navigationItem.rightBarButtonItem = nil
+            return
+        }
+
+        let deleteButton = UIButton(type: .system)
+        deleteButton.setTitle("삭제", for: .normal)
+        deleteButton.setTitleColor(.gray800, for: .normal)
+        deleteButton.titleLabel?.font = PotiFontManager.body14m.font
+        deleteButton.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
+        deleteButton.frame = CGRect(x: 0, y: 0, width: 48, height: 44)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: deleteButton)
+    }
+
+    @objc private func deleteButtonTapped() {
+        let alert = CustomAlertView(
+            title: "모집글을 삭제할까요?",
+            message: "삭제한 모집글은 복구할 수 없어요.",
+            cancelTitle: "취소",
+            confirmTitle: "삭제",
+            onLeftButton: {},
+            onRightButton: { [weak self] in
+                self?.viewModel.action(.tapDelete)
+            }
+        )
+        alert.show(on: navigationController?.view ?? view)
     }
 }
 

--- a/POTI-iOS/POTI-iOS/Presentation/Recruit/ViewModel/RecruitDetailViewModel.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Recruit/ViewModel/RecruitDetailViewModel.swift
@@ -13,6 +13,7 @@ final class RecruitDetailViewModel: BaseViewModelType {
     private let currentUserRole: UserRole = .host
     private let initialPostId: Int
     private var detailEntity: RecruitDetailEntity?
+    private var isDeleting = false
     
     // MARK: - Input
     
@@ -86,8 +87,10 @@ final class RecruitDetailViewModel: BaseViewModelType {
                 naviManageInfoSubject.send(postId)
             }
         case .tapDelete:
-            Task {
-                await deletePost()
+            guard !isDeleting else { return }
+            isDeleting = true
+            Task { [weak self] in
+                await self?.deletePost()
             }
         }
     }
@@ -107,7 +110,9 @@ final class RecruitDetailViewModel: BaseViewModelType {
     }
 
     private func deletePost() async {
-        guard let detailEntity, detailEntity.participant.isEmpty else {
+        defer { isDeleting = false }
+
+        guard let detailEntity, detailEntity.totalCount == 0 else {
             errorSubject.send("참여자가 있으면 모집글을 삭제할 수 없어요.")
             return
         }

--- a/POTI-iOS/POTI-iOS/Presentation/Recruit/ViewModel/RecruitDetailViewModel.swift
+++ b/POTI-iOS/POTI-iOS/Presentation/Recruit/ViewModel/RecruitDetailViewModel.swift
@@ -20,6 +20,7 @@ final class RecruitDetailViewModel: BaseViewModelType {
         case viewDidLoad
         case tapPotInfo
         case tapManageInfo
+        case tapDelete
     }
     
     // MARK: - Output
@@ -29,12 +30,14 @@ final class RecruitDetailViewModel: BaseViewModelType {
         let naviPotInfo: AnyPublisher<Int, Never>
         let naviManageInfo: AnyPublisher<Int, Never>
         let showError: AnyPublisher<String, Never>
+        let postDeleted: AnyPublisher<Void, Never>
     }
     
     // MARK: - Properties
     
     let output: Output
     private let postsSaleUseCase: PostsSaleUseCase
+    private let deletePostUseCase: DeletePostUseCase
     private let viewStateMapper = RecruitDetailViewStateMapper()
     
     // MARK: - Subject
@@ -43,22 +46,26 @@ final class RecruitDetailViewModel: BaseViewModelType {
     private let naviManageInfoSubject = PassthroughSubject<Int, Never>()
     private let viewStateSubject = CurrentValueSubject<RecruitDetailViewState?, Never>(nil)
     private let errorSubject = PassthroughSubject<String, Never>()
+    private let postDeletedSubject = PassthroughSubject<Void, Never>()
     
     // MARK: - Initializer
     
     init(
         postId: Int,
-        postsSaleUseCase: PostsSaleUseCase
+        postsSaleUseCase: PostsSaleUseCase,
+        deletePostUseCase: DeletePostUseCase
     ) {
         self.initialPostId = postId
         self.postsSaleUseCase = postsSaleUseCase
+        self.deletePostUseCase = deletePostUseCase
         self.output = Output(
             viewState: viewStateSubject
                 .compactMap { $0 }
                 .eraseToAnyPublisher(),
             naviPotInfo: naviPotInfoSubject.eraseToAnyPublisher(),
             naviManageInfo: naviManageInfoSubject.eraseToAnyPublisher(),
-            showError: errorSubject.eraseToAnyPublisher()
+            showError: errorSubject.eraseToAnyPublisher(),
+            postDeleted: postDeletedSubject.eraseToAnyPublisher()
         )
     }
     
@@ -78,6 +85,10 @@ final class RecruitDetailViewModel: BaseViewModelType {
             if let postId = self.detailEntity?.postId {
                 naviManageInfoSubject.send(postId)
             }
+        case .tapDelete:
+            Task {
+                await deletePost()
+            }
         }
     }
     // MARK: - Private Method
@@ -92,6 +103,20 @@ final class RecruitDetailViewModel: BaseViewModelType {
             viewStateSubject.send(state)
         } catch {
             errorSubject.send("분철 정보를 불러오지 못했어요")
+        }
+    }
+
+    private func deletePost() async {
+        guard let detailEntity, detailEntity.participant.isEmpty else {
+            errorSubject.send("참여자가 있으면 모집글을 삭제할 수 없어요.")
+            return
+        }
+
+        do {
+            try await deletePostUseCase.execute(postId: detailEntity.postId)
+            postDeletedSubject.send(())
+        } catch {
+            errorSubject.send("모집글을 삭제하지 못했어요.")
         }
     }
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치

- Resolved: #207 

## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

- 삭제 버튼 추가
- 뷰 업데이트 되도록
- 자잘한 오류  수정
<!--
```swift
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->

## 💬 To Reviewers  
<!-- 리뷰어들에게 하고 싶은 말 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 모집 게시글을 삭제할 수 있습니다.
  - 참여자가 없는 게시글에만 삭제 버튼이 표시되며, 확인 후 삭제됩니다.
  - 삭제가 완료되면 이전 화면으로 자동 이동합니다.

- **버그 수정**
  - 마이페이지의 참여·거래 내역이 화면에 다시 진입할 때 최신 상태로 갱신됩니다.
  - 내역 화면의 초기 탭 표시와 참여자 목록 갱신 시점을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->